### PR TITLE
Migrated VOR related changes from O_C repository

### DIFF
--- a/software/o_c_REV/OC_DAC.cpp
+++ b/software/o_c_REV/OC_DAC.cpp
@@ -64,16 +64,11 @@ void DAC::Init(CalibrationData *calibration_data) {
   #endif
   #endif
 
-  #if defined(VOR) || defined(OC_1U)
+#ifdef VOR
   // set Vbias, using onboard DAC:
   init_Vbias();
-  #ifdef VOR
-  set_Vbias(VBiasUnipolar);
-  #else
-  set_Vbias(VBiasAsymmetric);
-  #endif
   delay(10);
-  #endif
+#endif
 
   history_tail_ = 0;
   memset(history_, 0, sizeof(uint16_t) * kHistoryDepth * DAC_CHANNEL_LAST);

--- a/software/o_c_REV/OC_DAC.h
+++ b/software/o_c_REV/OC_DAC.h
@@ -41,15 +41,11 @@ public:
 
   #ifdef BUCHLA_4U
     static constexpr int kOctaveZero = 0;
-  #elif defined(VOR) || defined(OC_1U)
-    #ifdef OC_1U
-    static constexpr int kOctaveZero = 3; // todo: can't be a constant (eventually)
-    #else
+  #elif defined(VOR) 
     static constexpr int kOctaveZero = 0;
-    #endif
     static constexpr int VBiasUnipolar = 3900;   // onboard DAC @ Vref 1.2V (internal), 1.75x gain
     static constexpr int VBiasBipolar = 2000;    // onboard DAC @ Vref 1.2V (internal), 1.75x gain
-    static constexpr int VBiasAsymmetric = 2450; // onboard DAC @ Vref 1.2V (internal), 1.75x gain
+    static constexpr int VBiasAsymmetric = 2760; // onboard DAC @ Vref 1.2V (internal), 1.75x gain
   #else
     static constexpr int kOctaveZero = 3;
   #endif

--- a/software/o_c_REV/OC_autotuner.h
+++ b/software/o_c_REV/OC_autotuner.h
@@ -4,9 +4,17 @@
 #include "OC_autotune.h"
 #include "OC_options.h"
 
-#ifdef BUCHLA_4U
+#if defined(BUCHLA_4U) && !defined(IO_10V)
 const char* const AT_steps[] = {
   "0.0V", "1.2V", "2.4V", "3.6V", "4.8V", "6.0V", "7.2V", "8.4V", "9.6V", "10.8V", " " 
+};
+#elif defined(IO_10V)
+const char* const AT_steps[] = {
+  "0.0V", "1.0V", "2.0V", "3.0V", "4.0V", "5.0V", "6.0V", "7.0V", "8.0V", "9.0V", " " 
+};
+#elif defined(VOR)
+const char* const AT_steps[] = {
+  "0.0V", "1.0V", "2.0V", "3.0V", "4.0V", "5.0V", "6.0V", "7.0V", "8.0V", "9.0V", "10.0V", " " 
 };
 #else
 const char* const AT_steps[] = {

--- a/software/o_c_REV/OC_options.h
+++ b/software/o_c_REV/OC_options.h
@@ -25,9 +25,15 @@
 //#define DAC8564
 
 // This is the branch for the 10V OC Plus and VOR support, so these default to set
-#define IO_10V
+
+/* ------------ uncomment for use with Plum Audio VOR anabled versions (OCP, 1uO_c v2, 4Robots) ---------------------------------------------------------  */
 #define VOR
-//#define VOR_NO_RANGE_BUTTON
+/* ------------ uncomment for use with Plum Audio 1uO_c 4Robots (To use Up button long press to change VOR instead activate screensaver) ----------------  */
+#define VOR_NO_RANGE_BUTTON
+
+#if defined(VOR)
+  #define IO_10V
+#endif
 
 #endif
 

--- a/software/o_c_REV/OC_strings.h
+++ b/software/o_c_REV/OC_strings.h
@@ -17,6 +17,7 @@ namespace OC {
     extern const char * const channel_id[];
     extern const char * const note_names[];
     extern const char * const note_names_unpadded[];
+    extern const char * const VOR_offsets[];
     extern const char * const trigger_input_names[];
     extern const char * const trigger_input_names_none[];
     extern const char * const cv_input_names[];

--- a/software/o_c_REV/OC_ui.cpp
+++ b/software/o_c_REV/OC_ui.cpp
@@ -13,8 +13,11 @@
 #include "OC_version.h"
 #include "OC_options.h"
 #include "src/drivers/display.h"
+
+#ifdef VOR
 #include "VBiasManager.h"
 VBiasManager *VBiasManager::instance = 0;
+#endif
 
 extern uint_fast8_t MENU_REDRAW;
 
@@ -26,7 +29,12 @@ void Ui::Init() {
   ticks_ = 0;
   set_screensaver_timeout(SCREENSAVER_TIMEOUT_S);
 
+#if defined(VOR) && !defined(VOR_NO_RANGE_BUTTON)
+  static const int button_pins[] = { but_top, but_bot, butL, butR, but_mid };
+#else
   static const int button_pins[] = { but_top, but_bot, butL, butR };
+#endif
+
   for (size_t i = 0; i < CONTROL_BUTTON_LAST; ++i) {
     buttons_[i].Init(button_pins[i], OC_GPIO_BUTTON_PINMODE);
   }
@@ -178,7 +186,7 @@ UiMode Ui::Splashscreen(bool &reset_settings) {
       mode = UI_MODE_APP_SETTINGS;
 
     reset_settings =
-    #ifdef BUCHLA_4U
+    #if defined(BUCHLA_4U) && !defined(IO_10V)
        read_immediate(CONTROL_BUTTON_UP) && read_immediate(CONTROL_BUTTON_R);
     #else
        read_immediate(CONTROL_BUTTON_UP) && read_immediate(CONTROL_BUTTON_DOWN);

--- a/software/o_c_REV/OC_ui.h
+++ b/software/o_c_REV/OC_ui.h
@@ -34,7 +34,7 @@ enum UiControl {
   CONTROL_ENCODER_L   = 0x20,
   CONTROL_ENCODER_R   = 0x40,
 
-  #ifdef VOR
+  #if defined(VOR) && !defined(VOR_NO_RANGE_BUTTON)
   CONTROL_LAST = 6,
   CONTROL_BUTTON_LAST = 5,
   #else
@@ -124,8 +124,8 @@ private:
   uint32_t ticks_;
   uint32_t screensaver_timeout_;
 
-  UI::Button buttons_[4];
-  uint32_t button_press_time_[4];
+  UI::Button buttons_[CONTROL_BUTTON_LAST];
+  uint32_t button_press_time_[CONTROL_BUTTON_LAST];
   uint16_t button_state_;
   uint16_t button_ignore_mask_;
   bool screensaver_;

--- a/software/o_c_REV/VBiasManager.h
+++ b/software/o_c_REV/VBiasManager.h
@@ -28,6 +28,10 @@
 #ifndef VBIAS_MANAGER_H
 #define VBIAS_MANAGER_H
 
+#include "OC_options.h"
+
+#ifdef VOR 
+
 #define BIAS_EDITOR_TIMEOUT 16666
 
 class VBiasManager {
@@ -112,5 +116,7 @@ public:
         }
     }
 };
+
+#endif
 
 #endif // VBIAS_MANAGER_H

--- a/software/o_c_REV/braids_quantizer_scales.h
+++ b/software/o_c_REV/braids_quantizer_scales.h
@@ -107,21 +107,21 @@ const Scale scales[] = {
   // khamaj (From yarns source code)
   { 12 << 7, 8, { 0, 261, 494, 637, 899, 1160, 1275, 1421} },
   // mimal (From yarns source code)
-  { 12 << 7, 8, { 0, 261, 376, 637, 899, 1132, 1275, 1393} },
+  // { 12 << 7, 8, { 0, 261, 376, 637, 899, 1132, 1275, 1393} },
   // parameshwari (From yarns source code)
-  { 12 << 7, 6, { 0, 115, 376, 637, 1132, 1275} },
+  // { 12 << 7, 6, { 0, 115, 376, 637, 1132, 1275} },
   // rangeshwari (From yarns source code)
-  { 12 << 7, 6, { 0, 261, 376, 637, 899, 1393} },
+  // { 12 << 7, 6, { 0, 261, 376, 637, 899, 1393} },
   // gangeshwari (From yarns source code)
-  { 12 << 7, 6, { 0, 494, 637, 899, 1014, 1275} },
+  // { 12 << 7, 6, { 0, 494, 637, 899, 1014, 1275} },
   // kameshwari (From yarns source code)
-  { 12 << 7, 6, { 0, 261, 755, 899, 1132, 1275} },
+  // { 12 << 7, 6, { 0, 261, 755, 899, 1132, 1275} },
   // pa__kafi (From yarns source code)
-  { 12 << 7, 7, { 0, 261, 376, 637, 899, 1160, 1275} },
+  // { 12 << 7, 7, { 0, 261, 376, 637, 899, 1160, 1275} },
   // natbhairav (From yarns source code)
-  { 12 << 7, 7, { 0, 261, 494, 637, 899, 1014, 1393} },
+  // { 12 << 7, 7, { 0, 261, 494, 637, 899, 1014, 1393} },
   // m_kauns (From yarns source code)
-  { 12 << 7, 6, { 0, 261, 522, 637, 1014, 1275} },
+  // { 12 << 7, 6, { 0, 261, 522, 637, 1014, 1275} },
   // bairagi (From yarns source code)
   { 12 << 7, 5, { 0, 115, 637, 899, 1275} },
   // b_todi (From yarns source code)
@@ -168,6 +168,7 @@ const Scale scales[] = {
   // 17 TET Superpyth[12] - from Sevish Regular Temperaments Pack at http://sevish.com/music-resources
   { 12 << 7, 12, { 0, 90,  181, 361, 452, 632, 723, 813, 994, 1084,  1265,  1355} },
 
+  #ifndef VOR
   // 22 TET Orwell[9] - from Sevish Regular Temperaments Pack at http://sevish.com/music-resources
   { 12 << 7, 9, { 0, 140, 349, 489, 698, 838, 1047,  1187,  1396} },
   // 22 TET Pajara[10] Static Symmetrical Maj - from Sevish Regular Temperaments Pack at http://sevish.com/music-resources
@@ -246,33 +247,34 @@ const Scale scales[] = {
   { 12 << 7, 5, { 0,  404, 746, 1042,  1303} },
   // 4-HD2 (4 step harmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
   { 12 << 7, 4, { 0,  494, 899, 1240} },
+  #endif
 
   // 32-16-SD2 (16 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 16, { 0, 70,  143, 218, 296, 376, 460, 547, 637, 732, 830, 933, 1042,  1155,  1275,  1402} },
+  // { 12 << 7, 16, { 0, 70,  143, 218, 296, 376, 460, 547, 637, 732, 830, 933, 1042,  1155,  1275,  1402} },
   // 30-15-SD2 (15 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 15, { 0, 75,  153, 233, 317, 404, 494, 589, 687, 790, 899, 1012,  1132,  1259,  1393} },
+  // { 12 << 7, 15, { 0, 75,  153, 233, 317, 404, 494, 589, 687, 790, 899, 1012,  1132,  1259,  1393} },
   // 28-14-SD2 (14 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 14, { 0, 81,  164, 251, 342, 436, 534, 637, 746, 859, 979, 1106,  1240,  1383,  1536} },
+  // { 12 << 7, 14, { 0, 81,  164, 251, 342, 436, 534, 637, 746, 859, 979, 1106,  1240,  1383,  1536} },
   // 26-13-SD2 (13 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 13, { 0, 87,  177, 272, 370, 473, 581, 695, 815, 942, 1076,  1219,  1372} },
+  // { 12 << 7, 13, { 0, 87,  177, 272, 370, 473, 581, 695, 815, 942, 1076,  1219,  1372} },
   // 24-12-SD2 (12 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 12, { 0, 94,  193, 296, 404, 518, 637, 764, 899, 1042,  1194,  1359} },
+  // { 12 << 7, 12, { 0, 94,  193, 296, 404, 518, 637, 764, 899, 1042,  1194,  1359} },
   // 22-11-SD2 (11 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 11, { 0, 103, 211, 325, 445, 571, 706, 849, 1002,  1166,  1343} },
+  // { 12 << 7, 11, { 0, 103, 211, 325, 445, 571, 706, 849, 1002,  1166,  1343} },
   // 20-10-SD2 (10 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 10, { 0, 114, 233, 360, 494, 637, 790, 955, 1132,  1325} },
+  // { 12 << 7, 10, { 0, 114, 233, 360, 494, 637, 790, 955, 1132,  1325} },
   // 18-9-SD2 (9 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 9, { 0,  127, 261, 404, 557, 721, 899, 1091,  1303} },
+  // { 12 << 7, 9, { 0,  127, 261, 404, 557, 721, 899, 1091,  1303} },
   // 16-8-SD2 (8 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 8, { 0,  143, 296, 460, 637, 830, 1042,  1275} },
+  // { 12 << 7, 8, { 0,  143, 296, 460, 637, 830, 1042,  1275} },
   // 14-7-SD2 (7 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 7, { 0,  164, 342, 534, 746, 979, 1240} },
+  // { 12 << 7, 7, { 0,  164, 342, 534, 746, 979, 1240} },
   // 12-6-SD2 (6 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 6, { 0,  193, 404, 637, 899, 1194} },
+  // { 12 << 7, 6, { 0,  193, 404, 637, 899, 1194} },
   // 10-5-SD2 (5 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 5, { 0,  233, 494, 790, 1132} },
+  // { 12 << 7, 5, { 0,  233, 494, 790, 1132} },
   // 8-4-SD2 (4 step subharmonic series scale on the octave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-  { 12 << 7, 4, { 0,  296, 637, 1042} },
+  // { 12 << 7, 4, { 0,  296, 637, 1042} },
   
   // Bohlen-Pierce (equal) - see http://ziaspace.com/NYU/BP-Scale_research.pdf and https://en.wikipedia.org/wiki/Bohlen–Pierce_scale
   { 12 << 7, 13, { 0, 118, 236, 354, 473, 591, 709, 827, 945, 1063,  1182,  1300,  1418} },
@@ -282,26 +284,26 @@ const Scale scales[] = {
   { 12 << 7, 9, { 0, 244, 351, 470, 714, 822, 1066, 1185, 1428} },
 
 //  // 8-24-HD3 (16 step harmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 16, { 0, 165, 312, 445, 567, 679, 782, 879, 969, 1054,  1134,  1209,  1281,  1349,  1414,  1476} },
+// { 12 << 7, 16, { 0, 165, 312, 445, 567, 679, 782, 879, 969, 1054,  1134,  1209,  1281,  1349,  1414,  1476} },
 //  // 7-21-HD3 (14 step harmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 14, { 0, 187, 351, 499, 632, 754, 865, 969, 1066,  1156,  1241,  1320,  1396,  1468} },
+// { 12 << 7, 14, { 0, 187, 351, 499, 632, 754, 865, 969, 1066,  1156,  1241,  1320,  1396,  1468} },
 //  // 6-18-HD3 (12 step harmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 12, { 0, 216, 402, 567, 714, 847, 969, 1081,  1185,  1281,  1371,  1456} },
+// { 12 << 7, 12, { 0, 216, 402, 567, 714, 847, 969, 1081,  1185,  1281,  1371,  1456} },
 //  // 5-15-HD3 (10 step harmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 10, { 0, 255, 470, 657, 822, 969, 1102,  1224,  1336,  1440} },
+// { 12 << 7, 10, { 0, 255, 470, 657, 822, 969, 1102,  1224,  1336,  1440} },
 //  // 4-12-HD3 (8 step harmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 8, { 0,  312, 567, 782, 969, 1134,  1281,  1414} },
+// { 12 << 7, 8, { 0,  312, 567, 782, 969, 1134,  1281,  1414} },
 //
 //  // 24-8-HD3 (16 step subharmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 16, { 0, 60,  122, 187, 255, 327, 402, 482, 567, 657, 754, 857, 969, 1091,  1224,  1371} },
+// { 12 << 7, 16, { 0, 60,  122, 187, 255, 327, 402, 482, 567, 657, 754, 857, 969, 1091,  1224,  1371} },
 //  // 21-7-HD3 (14 step subharmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 14, { 0, 68,  140, 216, 295, 380, 470, 567, 671, 782, 904, 1037,  1185,  1349} },
+// { 12 << 7, 14, { 0, 68,  140, 216, 295, 380, 470, 567, 671, 782, 904, 1037,  1185,  1349} },
 //  // 18-6-HD3 (12 step subharmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 12, { 0, 80,  165, 255, 351, 455, 567, 689, 822, 969, 1134,  1320} },
+// { 12 << 7, 12, { 0, 80,  165, 255, 351, 455, 567, 689, 822, 969, 1134,  1320} },
 //  // 15-5-HD3 (10 step subharmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 10, { 0, 96,  200, 312, 434, 567, 714, 879, 1066,  1281} },
+// { 12 << 7, 10, { 0, 96,  200, 312, 434, 567, 714, 879, 1066,  1281} },
 //  // 12-4-HD3 (8 step subharmonic series scale on the tritave) - see Xen-Arts VSTi microtuning library at http://www.xen-arts.net/Xen-Arts%20VSTi%20Microtuning%20Library.zip
-{ 12 << 7, 8, { 0,  122, 255, 402, 567, 754, 969, 1224} }
+// { 12 << 7, 8, { 0,  122, 255, 402, 567, 754, 969, 1224} }
   } ;
 }// namespace braids
 

--- a/software/o_c_REV/o_c_REV.ino
+++ b/software/o_c_REV/o_c_REV.ino
@@ -148,6 +148,11 @@ void setup() {
 
   // initialize apps
   OC::apps::Init(reset_settings);
+
+#ifdef VOR
+  VBiasManager *vbias_m = vbias_m->get();
+  vbias_m->ChangeBiasToState(VBiasManager::UNI);
+#endif
 }
 
 /*  ---------    main loop  --------  */
@@ -172,8 +177,13 @@ void FASTRUN loop() {
           OC_DEBUG_PROFILE_SCOPE(OC::DEBUG::MENU_draw_cycles);
           OC::apps::current_app->DrawMenu();
           ++menu_redraws;
+
+          #ifdef VOR
+          // JEJ:On app screens, show the bias popup, if necessary
           VBiasManager *vbias_m = vbias_m->get();
           vbias_m->DrawPopupPerhaps();
+          #endif
+
         } else {
           //Blank the screen instead of drawing the screensaver (chysn 9/2/2018)
           //OC::apps::current_app->DrawScreensaver();


### PR DESCRIPTION
Moved some VOR related changes from the main O_C code to get basic VOR
functionality working on the ocplus branch of Hemisphere Suite. The
current branch doesn't run on my Plum Audio 4Robots 1U O_c. With these
changes it runs, VOR is set to Unipolar on startup but can be changed
from the long click menu. Not tested on other VOR hardware though no
reason why it shouldn't run.

Other than copying relevant bits from the main O_C repository I also
matched the scales being exposed in braids_quantizer_scales to that
in OC_scales.cpp

Currently the bias is initialised at the end of the setup function in
o_c_REV.ino. For some reason doing this earlier didn't work. Not sure
if there is a better way to do this.