### PR TITLE
Fix a display bug when Annular Fusion is saved in the eeprom

### DIFF
--- a/software/o_c_REV/HEM_AnnularFusion.ino
+++ b/software/o_c_REV/HEM_AnnularFusion.ino
@@ -113,6 +113,8 @@ public:
         beats[0] = Unpack(data, PackLocation {4,4}) + 1;
         length[1] = Unpack(data, PackLocation {8,4}) + 1;
         beats[1] = Unpack(data, PackLocation {12,4}) + 1;
+        SetDisplayPositions(0, 24);
+        SetDisplayPositions(1, 16);
     }
 
 protected:


### PR DESCRIPTION
This is to ensure the display is correct when recovering data saved