### PR TITLE
Add temporary message that calibration is messed up on ocplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### Attention!! If you are using an O+C Plus, do NOT calibrate it using this fork of Hemispheres! Nothing will break, but you will calibrate it incorrectly. Please install the classic O+C Firmware with VOR enabled and calibrate there, only then install this firmware.
+
 Hemisphere Suite: Alternate Alternate Firmware for Ornament and Crime
 ===
 


### PR DESCRIPTION
So that I can sleep soundly until I fix the calibration menu and nobody wastes their time calibrating the module with this branch of Hemispheres.