### PR TITLE
Save internal clock state

### DIFF
--- a/software/o_c_REV/APP_HEMISPHERE.ino
+++ b/software/o_c_REV/APP_HEMISPHERE.ino
@@ -253,7 +253,7 @@ public:
         RequestAppletData();
 
         // Describe the data structure for the audience
-        uint8_t V[12];
+        uint8_t V[10];
         V[0] = (uint8_t)values_[HEMISPHERE_SELECTED_LEFT_ID];
         V[1] = (uint8_t)values_[HEMISPHERE_SELECTED_RIGHT_ID];
         V[2] = (uint8_t)(values_[HEMISPHERE_LEFT_DATA_L] & 0xff);
@@ -264,18 +264,16 @@ public:
         V[7] = (uint8_t)((values_[HEMISPHERE_LEFT_DATA_H] >> 8) & 0xff);
         V[8] = (uint8_t)(values_[HEMISPHERE_RIGHT_DATA_H] & 0xff);
         V[9] = (uint8_t)((values_[HEMISPHERE_RIGHT_DATA_H] >> 8) & 0xff);
-        V[10] = (uint8_t)(values_[HEMISPHERE_CLOCK_DATA] & 0xff);
-        V[11] = (uint8_t)((values_[HEMISPHERE_CLOCK_DATA] >> 8) & 0xff);
 
         // Pack it up, ship it out
         UnpackedData unpacked;
-        unpacked.set_data(12, V);
+        unpacked.set_data(10, V);
         PackedData packed = unpacked.pack();
         SendSysEx(packed, 'H');
     }
 
     void OnReceiveSysEx() {
-        uint8_t V[12];
+        uint8_t V[10];
         if (ExtractSysExData(V, 'H')) {
             values_[HEMISPHERE_SELECTED_LEFT_ID] = V[0];
             values_[HEMISPHERE_SELECTED_RIGHT_ID] = V[1];
@@ -283,7 +281,6 @@ public:
             values_[HEMISPHERE_RIGHT_DATA_L] = ((uint16_t)V[5] << 8) + V[4];
             values_[HEMISPHERE_LEFT_DATA_H] = ((uint16_t)V[7] << 8) + V[6];
             values_[HEMISPHERE_RIGHT_DATA_H] = ((uint16_t)V[9] << 8) + V[8];
-            values_[HEMISPHERE_CLOCK_DATA] = ((uint16_t)V[11] << 8) + V[10];
             Resume();
         }
     }

--- a/software/o_c_REV/HEM_ClockSetup.ino
+++ b/software/o_c_REV/HEM_ClockSetup.ino
@@ -60,9 +60,25 @@ public:
             clock_m->SetMultiply(mult);
         }
     }
-        
-    uint32_t OnDataRequest() {return 0;}
-    void OnDataReceive(uint32_t data) { }
+
+    uint32_t OnDataRequest() {
+        uint32_t data = 0;
+        Pack(data, PackLocation { 0, 1 }, clock_m->IsRunning() || clock_m->IsPaused());
+        Pack(data, PackLocation { 1, 9 }, clock_m->GetTempo());
+        Pack(data, PackLocation { 10, 5 }, clock_m->GetMultiply());
+        return data;
+    }
+
+    void OnDataReceive(uint32_t data) {
+        if (Unpack(data, PackLocation { 0, 1 })) {
+            clock_m->Start();
+            clock_m->Pause();
+        } else {
+            clock_m->Stop();
+        }
+        clock_m->SetTempoBPM(Unpack(data, PackLocation { 1, 9 }));
+        clock_m->SetMultiply(Unpack(data, PackLocation { 10, 5 }));
+    }
 
 protected:
     void SetHelp() {
@@ -73,11 +89,11 @@ protected:
         help[HEMISPHERE_HELP_ENCODER]  = "";
         //                               "------------------" <-- Size Guide
     }
-    
+
 private:
     int cursor; // 0=Source, 1=Tempo, 2=Multiply
     ClockManager *clock_m = clock_m->get();
-    
+
     void DrawInterface() {
         // Header: This is sort of a faux applet, so its header
         // needs to extend across the screen


### PR DESCRIPTION
This adds the master clock state to the saved settings so that users do not have to re-adjust mode, bpm, and multiplier on restart.

A few notes:

- **State is saved via `ClockSetup`'s `OnData` methods**: This seemed a reasonable place to put it and gave access to the pack methods. Happy to change it to save `ClockManager` state directly if preferred; would just require duplicating some of the packing logic.
- **On settings reset, clock state does not reset until device restart**: This matches the behavior of the ADSR and ScaleDuet applets if they are currently selected. If this is undesirable, I'd be happy to open a separate PR that resets both clock and applet state. Alternatively, I could put in a clock-specific reset, though that would be inconsistent with the treatment of the applets.

Happy to make changes as needed!