### PR TITLE
Set -5V~5V to be OCP's default VOR setting, not 0V-10V

### DIFF
--- a/software/o_c_REV/VBiasManager.h
+++ b/software/o_c_REV/VBiasManager.h
@@ -45,9 +45,9 @@ class VBiasManager {
     }
 
 public:
-    static const int UNI = 0;
+    static const int BI = 0;
     static const int ASYM = 1;
-    static const int BI = 2;
+    static const int UNI = 2;
 
     static VBiasManager *get() {
         if (!instance) instance = new VBiasManager;
@@ -78,7 +78,7 @@ public:
      *
      * #ifdef VOR
      *     VBiasManager *vbias_m = vbias_m->get();
-     *     vbias_m->ChangeBiasToState(VBiasManager::UNI);
+     *     vbias_m->ChangeBiasToState(VBiasManager::BI);
      * #endif
      *
      */
@@ -101,15 +101,15 @@ public:
             graphics.setPrintPos(20, 10);
             graphics.print("Range:");
 
-            // Unipolar state
+            // Bipolar state
             graphics.setPrintPos(30, 20);
-            graphics.print(" 0V -> 10V");
+            graphics.print("-5V -> 5V");
             // Asym State
             graphics.setPrintPos(30, 30);
             graphics.print("-3V -> 7V");
-            // Bipolar state
+            // Unipolar state
             graphics.setPrintPos(30, 40);
-            graphics.print("-5V -> 5V");
+            graphics.print(" 0V -> 10V");
 
             graphics.setPrintPos(20, 20 + (bias_state * 10));
             graphics.print("> ");

--- a/software/o_c_REV/o_c_REV.ino
+++ b/software/o_c_REV/o_c_REV.ino
@@ -151,7 +151,7 @@ void setup() {
 
 #ifdef VOR
   VBiasManager *vbias_m = vbias_m->get();
-  vbias_m->ChangeBiasToState(VBiasManager::UNI);
+  vbias_m->ChangeBiasToState(VBiasManager::BI);
 #endif
 }
 


### PR DESCRIPTION
I think we can agree that the OCP's VOR settings are a bit esoteric, especially when using Hemispheres they are not very common. Because of this I think it makes sense to make the default the normal behavior of Hemispheres, so an output range of -5V to 5V, not a range of 0V to 10V which is currently the default and almost never useful (to me). 